### PR TITLE
6 migrate to std::unique_ptr

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,6 +1,6 @@
 cmake_minimum_required(VERSION 3.21)
 
-project(my-project)
+project(ignosi-memory)
 
 execute_process(
   COMMAND

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -83,7 +83,7 @@ steps:
     workingDirectory: '.' 
     cmakeArgs: --build $(Build.BinariesDirectory) 
     
-- script: $(Build.BinariesDirectory)/test/ignosi-test
+- script: $(Build.BinariesDirectory)/test/ignosi-memory-test
   displayName: "Run Unit Tests"
 
 - task: PublishTestResults@2

--- a/lib/CMakeLists.txt
+++ b/lib/CMakeLists.txt
@@ -1,3 +1,5 @@
 cmake_minimum_required(VERSION 3.21)
 
+add_subdirectory("allocate")
+add_subdirectory("allocate-cpp")
 add_subdirectory("dll")

--- a/lib/allocate-cpp/CMakeLists.txt
+++ b/lib/allocate-cpp/CMakeLists.txt
@@ -1,11 +1,9 @@
 cmake_minimum_required(VERSION 3.21)
 
-project(ignosi-allocate-cpp)
+project(ignosi-memory-allocate-cpp)
 
 set(CMAKE_CXX_STANDARD 20)
 
-add_library(${PROJECT_NAME} INTERFACE )
+add_library(${PROJECT_NAME} INTERFACE)
 target_include_directories(${PROJECT_NAME} INTERFACE ${CMAKE_CURRENT_LIST_DIR})
-target_link_libraries(${PROJECT_NAME} INTERFACE ignosi-allocate)
-
-
+target_link_libraries(${PROJECT_NAME} INTERFACE ignosi-memory-allocate)

--- a/lib/allocate-cpp/CMakeLists.txt
+++ b/lib/allocate-cpp/CMakeLists.txt
@@ -1,10 +1,11 @@
 cmake_minimum_required(VERSION 3.21)
 
-project(ignosi-dll)
+project(ignosi-allocate-cpp)
 
 set(CMAKE_CXX_STANDARD 20)
 
 add_library(${PROJECT_NAME} INTERFACE )
 target_include_directories(${PROJECT_NAME} INTERFACE ${CMAKE_CURRENT_LIST_DIR})
+target_link_libraries(${PROJECT_NAME} INTERFACE ignosi-allocate)
 
 

--- a/lib/allocate-cpp/dll_allocator.hpp
+++ b/lib/allocate-cpp/dll_allocator.hpp
@@ -1,9 +1,11 @@
 #pragma once
 
+#include <dll_allocate.h>
+
 #include <limits>
 #include <new>
 
-namespace Ignosi::dll {
+namespace ignosi::memory {
 
 template <typename T>
 class dll_allocator {
@@ -19,14 +21,14 @@ class dll_allocator {
     if (n > std::numeric_limits<std::size_t>::max() / sizeof(T))
       throw std::bad_array_new_length();
 
-    if (auto p = static_cast<T*>(dll_allocate(n * sizeof(T)))) {
+    if (auto p = static_cast<T*>(ignosi_memory_allocate(n * sizeof(T)))) {
       return p;
     }
 
     throw std::bad_alloc();
   }
 
-  void deallocate(T* p, std::size_t) noexcept { dll_deallocate(p); }
+  void deallocate(T* p, std::size_t) noexcept { ignosi_memory_deallocate(p); }
 };
 
 template <class T, class U>

--- a/lib/allocate-cpp/dll_pointer.hpp
+++ b/lib/allocate-cpp/dll_pointer.hpp
@@ -1,12 +1,12 @@
 #pragma once
 
+#include <dll_allocate.h>
+
 #include <cassert>
 #include <memory>
 #include <utility>
 
-#include "dll_allocate.h"
-
-namespace Ignosi::dll {
+namespace ignosi::memory {
 
 template <typename T>
 using dll_unique_ptr = std::unique_ptr<T, void (*)(T*)>;
@@ -15,20 +15,20 @@ template <typename T>
 static void destroy(T* pObj) {
   if (pObj) {
     pObj->~T();
-    dll_deallocate(pObj);
+    ignosi_memory_deallocate(pObj);
   }
 }
 
 template <typename T, typename... Args>
 dll_unique_ptr<T> make_unique_dll_obj(Args... args) {
-  void* pNewMem = dll_allocate(sizeof(T));
+  void* pNewMem = ignosi_memory_allocate(sizeof(T));
 
   if (pNewMem) {
     try {
       T* newObj = new (pNewMem) T(std::forward<Args>(args)...);
       return dll_unique_ptr<T>(newObj, &destroy);
     } catch (...) {
-      dll_deallocate(pNewMem);
+      ignosi_memory_deallocate(pNewMem);
       throw;
     }
   }
@@ -40,4 +40,4 @@ dll_unique_ptr<U> cast_unique_dll_ptr(dll_unique_ptr<T>&& obj) {
   return dll_unique_ptr<U>(static_cast<U*>(obj.release()), &destroy<U>);
 }
 
-}  // namespace Ignosi::dll
+}  // namespace ignosi::memory

--- a/lib/allocate/CMakeLists.txt
+++ b/lib/allocate/CMakeLists.txt
@@ -1,6 +1,6 @@
 cmake_minimum_required(VERSION 3.21)
 
-project(ignosi-allocate)
+project(ignosi-memory-allocate)
 
 set(CMAKE_CXX_STANDARD 20)
 

--- a/lib/allocate/CMakeLists.txt
+++ b/lib/allocate/CMakeLists.txt
@@ -1,0 +1,13 @@
+cmake_minimum_required(VERSION 3.21)
+
+project(ignosi-allocate)
+
+set(CMAKE_CXX_STANDARD 20)
+
+add_library(${PROJECT_NAME} SHARED "dll_allocate.cpp")
+target_compile_definitions(${PROJECT_NAME} PRIVATE EXPORT)
+
+target_include_directories(${PROJECT_NAME} PUBLIC ${CMAKE_CURRENT_LIST_DIR})
+target_link_libraries(${PROJECT_NAME} PUBLIC ignosi-dll)
+
+set_target_properties(${PROJECT_NAME} PROPERTIES VERSION 1.0.0 SOVERSION 1)

--- a/lib/allocate/dll_allocate.cpp
+++ b/lib/allocate/dll_allocate.cpp
@@ -3,11 +3,11 @@
 #include <cstdlib>
 #include <limits>
 
-DLL_FUNC(void*) dll_allocate(std::uint64_t size) {
+EXPORT_SPEC void* ignosi_memory_allocate(std::uint64_t size) {
   if (size > std::numeric_limits<size_t>::max()) {
     return nullptr;
   }
   return std::malloc(static_cast<size_t>(size));
 }
 
-DLL_FUNC(void) dll_deallocate(void* obj) { return std::free(obj); }
+EXPORT_SPEC void ignosi_memory_deallocate(void* obj) { return std::free(obj); }

--- a/lib/allocate/dll_allocate.h
+++ b/lib/allocate/dll_allocate.h
@@ -1,0 +1,10 @@
+#pragma once
+
+#include <dll_defines.h>
+
+#include <cstdint>
+
+extern "C" {
+EXPORT_SPEC void* ignosi_memory_allocate(std::uint64_t size);
+EXPORT_SPEC void ignosi_memory_deallocate(void* obj);
+}

--- a/lib/dll/CMakeLists.txt
+++ b/lib/dll/CMakeLists.txt
@@ -4,7 +4,5 @@ project(ignosi-dll)
 
 set(CMAKE_CXX_STANDARD 20)
 
-add_library(${PROJECT_NAME} INTERFACE )
+add_library(${PROJECT_NAME} INTERFACE)
 target_include_directories(${PROJECT_NAME} INTERFACE ${CMAKE_CURRENT_LIST_DIR})
-
-

--- a/lib/dll/dll_allocate.h
+++ b/lib/dll/dll_allocate.h
@@ -1,8 +1,0 @@
-#pragma once
-
-#include <cstdint>
-
-#include "dll_defines.h"
-
-DLL_FUNC(void*) dll_allocate(std::uint64_t size);
-DLL_FUNC(void) dll_deallocate(void* obj);

--- a/lib/dll/dll_defines.h
+++ b/lib/dll/dll_defines.h
@@ -1,6 +1,5 @@
 #pragma once
 
-#ifndef DLL_FUNC
 #ifdef EXPORT
 #ifdef _WIN32
 #define EXPORT_SPEC __declspec(dllexport)
@@ -14,15 +13,3 @@
 #define EXPORT_SPEC
 #endif  // _WIN32
 #endif  // !EXPORT
-
-#ifndef CALL
-
-#ifdef _WIN32
-#define CALL __stdcall
-#else
-#define CALL
-#endif  // _WIN32
-#endif  // !CALL
-
-#define DLL_FUNC(RETURN_T) extern "C" EXPORT_SPEC RETURN_T CALL
-#endif  // !DLL_FUNC

--- a/lib/dll/dll_pointer.hpp
+++ b/lib/dll/dll_pointer.hpp
@@ -12,95 +12,32 @@ template <typename T>
 using dll_unique_ptr = std::unique_ptr<T, void (*)(T*)>;
 
 template <typename T>
-class dll_pointer {
-  T* m_pObj{nullptr};
-
- public:
-  dll_pointer() = default;
-  dll_pointer(T* pObj) : m_pObj(pObj) {}
-
-  dll_pointer(std::unique_ptr<T>&& other) : m_pObj(other.release()) {}
-
-  dll_pointer(const dll_pointer& other) = delete;
-  dll_pointer(dll_pointer&& other) noexcept : m_pObj(other.release()) {}
-
-  template <typename U>
-  dll_pointer(dll_pointer<U>&& other) noexcept
-      : m_pObj(static_cast<T*>(other.release())) {}
-
-  ~dll_pointer() {
-    destroy(m_pObj);
-    m_pObj = nullptr;
+static void destroy(T* pObj) {
+  if (pObj) {
+    pObj->~T();
+    dll_deallocate(pObj);
   }
-
-  T* operator->() noexcept { return m_pObj; }
-  const T* operator->() const noexcept { return m_pObj; }
-
-  T& operator*() {
-    assert(m_pObj);
-    return *m_pObj;
-  }
-  const T& operator*() const {
-    assert(m_pObj);
-    return *m_pObj;
-  }
-
-  dll_pointer& operator=(const dll_pointer& other) = delete;
-  dll_pointer& operator=(dll_pointer&& other) noexcept {
-    reset(other.release());
-    return *this;
-  }
-
-  template <typename U>
-  dll_pointer& operator=(dll_pointer<U>&& other) noexcept {
-    reset(static_cast<T*>(other.release()));
-    return *this;
-  }
-
-  T* get() noexcept { return m_pObj; }
-  const T* get() const noexcept { return m_pObj; }
-
-  T* release() {
-    T* pTmp = m_pObj;
-    m_pObj = nullptr;
-    return pTmp;
-  }
-
-  void reset(T* pObj) noexcept {
-    destroy(m_pObj);
-    m_pObj = pObj;
-  }
-
-  friend bool operator==(const dll_pointer& lhs,
-                         const dll_pointer& rhs) = default;
-
-  friend bool operator!=(const dll_pointer& lhs,
-                         const dll_pointer& rhs) = default;
-
-  explicit operator bool() const noexcept { return m_pObj != nullptr; }
-
-  static void destroy(T* pObj) {
-    if (pObj) {
-      pObj->~T();
-      dll_deallocate(pObj);
-    }
-  }
-};
+}
 
 template <typename T, typename... Args>
-dll_pointer<T> make_unique_dll_obj(Args... args) {
+dll_unique_ptr<T> make_unique_dll_obj(Args... args) {
   void* pNewMem = dll_allocate(sizeof(T));
 
   if (pNewMem) {
     try {
       T* newObj = new (pNewMem) T(std::forward<Args>(args)...);
-      return dll_pointer<T>(newObj);
+      return dll_unique_ptr<T>(newObj, &destroy);
     } catch (...) {
       dll_deallocate(pNewMem);
       throw;
     }
   }
   throw std::bad_alloc();
+}
+
+template <typename U, typename T>
+dll_unique_ptr<U> cast_unique_dll_ptr(dll_unique_ptr<T>&& obj) {
+  return dll_unique_ptr<U>(static_cast<U*>(obj.release()), &destroy<U>);
 }
 
 }  // namespace Ignosi::dll

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -1,6 +1,6 @@
 cmake_minimum_required(VERSION 3.21)
 
-project(ignosi-test)
+project(ignosi-memory-test)
 
 include(GoogleTest)
 
@@ -11,7 +11,8 @@ add_executable(${PROJECT_NAME} "main.cpp" "dll_allocate_tests.cpp")
 find_package(GTest CONFIG REQUIRED)
 find_package(fmt CONFIG REQUIRED)
 
-target_link_libraries(${PROJECT_NAME} PRIVATE GTest::gtest ignosi-allocate-cpp fmt::fmt)
+target_link_libraries(${PROJECT_NAME}
+                      PRIVATE GTest::gtest ignosi-memory-allocate-cpp fmt::fmt)
 
 gtest_add_tests(TARGET ${PROJECT_NAME})
 if(WIN32)

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -11,7 +11,7 @@ add_executable(${PROJECT_NAME} "main.cpp" "dll_allocate_tests.cpp")
 find_package(GTest CONFIG REQUIRED)
 find_package(fmt CONFIG REQUIRED)
 
-target_link_libraries(${PROJECT_NAME} PRIVATE GTest::gtest ignosi-dll fmt::fmt)
+target_link_libraries(${PROJECT_NAME} PRIVATE GTest::gtest ignosi-allocate-cpp fmt::fmt)
 
 gtest_add_tests(TARGET ${PROJECT_NAME})
 if(WIN32)

--- a/test/dll_allocate_tests.cpp
+++ b/test/dll_allocate_tests.cpp
@@ -79,7 +79,7 @@ TEST_F(dll_allocate_fixture, validate_create_destroy) {
 }
 
 TEST_F(dll_allocate_fixture, validate_create_destroy_args) {
-  dll::dll_pointer<TestObject> ptr =
+  dll::dll_unique_ptr<TestObject> ptr =
       dll::make_unique_dll_obj<TestObject>(1.0, 2.0);
 
   ASSERT_EQ(*ptr, TestObject(1.0, 2.0));
@@ -90,25 +90,16 @@ TEST_F(dll_allocate_fixture, validate_create_throwing_object) {
                std::runtime_error);
 }
 
-TEST_F(dll_allocate_fixture, validate_convert_unique_ptr) {
-  dll::dll_pointer<TestObject> pObj = dll::make_unique_dll_obj<TestObject>();
-  dll::dll_unique_ptr<TestObject> pObjUnique(
-      pObj.release(), &(dll::dll_pointer<TestObject>::destroy));
-
-  ASSERT_EQ(pObj.get(), nullptr);
-  ASSERT_NE(pObjUnique.get(), nullptr);
-}
-
 TEST_F(dll_allocate_fixture, validate_create_derived) {
-  dll::dll_pointer<TestObject> pObj =
-      dll::make_unique_dll_obj<DerivedTestObject>();
+  dll::dll_unique_ptr<TestObject> pObj = dll::cast_unique_dll_ptr<TestObject>(
+      dll::make_unique_dll_obj<DerivedTestObject>());
 }
 
 TEST_F(dll_allocate_fixture, validate_create_shared_derived) {
-  dll::dll_pointer<DerivedTestObject> pObj =
+  dll::dll_unique_ptr<DerivedTestObject> pObj =
       dll::make_unique_dll_obj<DerivedTestObject>(1.0, 2.0, 3.0);
   std::shared_ptr<DerivedTestObject> pObjShared1(
-      pObj.release(), &(dll::dll_pointer<TestObject>::destroy));
+      pObj.release(), &dll::destroy<DerivedTestObject>);
   std::shared_ptr<TestObject> pObjShared2(pObjShared1);
 
   pObjShared1->Value1 = 10.0;

--- a/test/dll_allocate_tests.cpp
+++ b/test/dll_allocate_tests.cpp
@@ -11,8 +11,6 @@
 namespace ignosi::memory::test {
 namespace {
 
-struct TestObject;
-
 struct TestObject {
   TestObject() : Value1(0.0), Value2(0.0) {}
   TestObject(double value1, double value2) : Value1(value1), Value2(value2) {}

--- a/test/dll_allocate_tests.cpp
+++ b/test/dll_allocate_tests.cpp
@@ -8,7 +8,7 @@
 
 #include "memory_leak_detector.h"
 
-namespace Ignosi::test {
+namespace ignosi::memory::test {
 namespace {
 
 struct TestObject;
@@ -75,31 +75,31 @@ struct DerivedTestObject : public TestObject {
 class dll_allocate_fixture : public memory_leak_detector_fixture {};
 
 TEST_F(dll_allocate_fixture, validate_create_destroy) {
-  ASSERT_NO_THROW(dll::make_unique_dll_obj<TestObject>());
+  ASSERT_NO_THROW(make_unique_dll_obj<TestObject>());
 }
 
 TEST_F(dll_allocate_fixture, validate_create_destroy_args) {
-  dll::dll_unique_ptr<TestObject> ptr =
-      dll::make_unique_dll_obj<TestObject>(1.0, 2.0);
+  dll_unique_ptr<TestObject> ptr =
+      make_unique_dll_obj<TestObject>(1.0, 2.0);
 
   ASSERT_EQ(*ptr, TestObject(1.0, 2.0));
 }
 
 TEST_F(dll_allocate_fixture, validate_create_throwing_object) {
-  ASSERT_THROW(dll::make_unique_dll_obj<ThrowingTestObject>(),
+  ASSERT_THROW(make_unique_dll_obj<ThrowingTestObject>(),
                std::runtime_error);
 }
 
 TEST_F(dll_allocate_fixture, validate_create_derived) {
-  dll::dll_unique_ptr<TestObject> pObj = dll::cast_unique_dll_ptr<TestObject>(
-      dll::make_unique_dll_obj<DerivedTestObject>());
+  dll_unique_ptr<TestObject> pObj = cast_unique_dll_ptr<TestObject>(
+      make_unique_dll_obj<DerivedTestObject>());
 }
 
 TEST_F(dll_allocate_fixture, validate_create_shared_derived) {
-  dll::dll_unique_ptr<DerivedTestObject> pObj =
-      dll::make_unique_dll_obj<DerivedTestObject>(1.0, 2.0, 3.0);
+  dll_unique_ptr<DerivedTestObject> pObj =
+      make_unique_dll_obj<DerivedTestObject>(1.0, 2.0, 3.0);
   std::shared_ptr<DerivedTestObject> pObjShared1(
-      pObj.release(), &dll::destroy<DerivedTestObject>);
+      pObj.release(), &destroy<DerivedTestObject>);
   std::shared_ptr<TestObject> pObjShared2(pObjShared1);
 
   pObjShared1->Value1 = 10.0;
@@ -111,9 +111,9 @@ TEST_F(dll_allocate_fixture, validate_create_shared_derived) {
 }
 
 TEST_F(dll_allocate_fixture, validate_create_dll_allocator) {
-  std::vector<TestObject, dll::dll_allocator<TestObject>> testVector;
+  std::vector<TestObject, dll_allocator<TestObject>> testVector;
   for (double i = 0.0; i < 10.0; ++i) {
     ASSERT_NO_THROW(testVector.push_back(TestObject(i, i * 2.0)));
   }
 }
-}  // namespace Ignosi::test
+}  // namespace ignosi::memory::test


### PR DESCRIPTION
 - refactor repo layout to better reflect code uses
 - renamed namespaces to properly reflect project name